### PR TITLE
deploy.rbの編集

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,8 +5,8 @@ set :repo_url, "git@example.com:Yuki-Inagawa/freemarket_sample_55b"
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
 set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'
-set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['~/.ssh/mercari.pem']
+set :ssh_options, auth_methods: 'publickey',
+                  keys: '~/.ssh/mercari.pem'
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5


### PR DESCRIPTION
# what
自動デプロイで参照する鍵へのパスに不要な[]が付いていた為修正

# why
自動デプロイのエラーを解消する為