### PR TITLE
デプロイ環境の再設定

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # config valid for current version and patch releases of Capistrano
 lock "~> 3.11.0"
 set :application, "freemarket_sample_55b"
-set :repo_url, "git@example.com:Yuki-Inagawa/freemarket_sample_55b"
+set :repo_url, "git@github.com:Yuki-Inagawa/freemarket_sample_55b"
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
 set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'


### PR DESCRIPTION
# what
デプロイ時に参照するdeploy.rb内のset :repo_url,の記述が間違っていた為修正

# why
自動デプロイをする為