### PR TITLE
sms-registration-view Update

### DIFF
--- a/app/assets/stylesheets/yukawa.scss
+++ b/app/assets/stylesheets/yukawa.scss
@@ -71,12 +71,12 @@
             content: '';
             width: 100%;
             height: 2px;
-            background: #ccc;
             border-style: solid;
             border-width: 0;
             text-decoration: inherit;
             vertical-align: inherit;
             box-sizing: inherit;
+            background: #ea352d;
           }
           .progress-status:before {
             right: 50%;
@@ -87,13 +87,22 @@
             content: '';
             width: 100%;
             height: 2px;
-            background: #ccc;
+            background: #ea352d;
           }
           .first:before {
             content: none;
           }
           .last:after {
             content: none;
+          }
+          .gray:before {
+            background: #ccc;
+          }
+          .gray:after {
+            background: #ccc;
+          }
+          .right-gray:after {
+            background: #ccc;
           }
         }
         .active {
@@ -149,6 +158,10 @@
               font-size: 16px;
               box-sizing: border-box;
             }
+          }
+          .sms-info {
+            margin: 8px 0 0;
+            line-height: 1.5;
           }
           &--form {
             margin-top: 32px;

--- a/app/controllers/yukawa_controller.rb
+++ b/app/controllers/yukawa_controller.rb
@@ -6,4 +6,7 @@ class YukawaController < ApplicationController
   def registration
   end
 
+  def sms_confirmation
+  end
+
 end

--- a/app/views/yukawa/registration.html.haml
+++ b/app/views/yukawa/registration.html.haml
@@ -1,24 +1,24 @@
 .single-container
   %header.single-header
     %h1.mercari-logo
-      = link_to image_tag("logo.svg", alt: "Google Play画像"), "/yukawa/registration", class: "mercari-logo__link"
+      = link_to image_tag("logo.svg", alt: "mercari"), "/yukawa/registration", class: "mercari-logo__link"
     %nav.progress-bar
       %ol.clearfix
         %li.active
           会員情報
-          .progress-status.first
+          .progress-status.first.right-gray
         %li 
           電話番号認証
-          .progress-status
+          .progress-status.gray
         %li 
           お届け先住所入力
-          .progress-status
+          .progress-status.gray
         %li 
           支払い方法
-          .progress-status
+          .progress-status.gray
         %li 
           完了
-          .progress-status.last
+          .progress-status.last.gray
   %main.single-main
     %section.l-single-container
       %h2.new-registration 会員情報入力
@@ -253,7 +253,7 @@
           %button{type: "submit", class: "next-btn"}次へ進む
           .new-registration-form__content--form.text-right
             %p
-              =link_to "本人情報の登録について", "/yukawa/registration/"
+              =link_to "本人情報の登録について", "/yukawa/sms_confirmation", method: 'get'
               =fa_icon "angle-right", class: "arrow-right"
   %footer.single-footer
     フッターは部分テンプレートです。

--- a/app/views/yukawa/sms_confirmation.html.haml
+++ b/app/views/yukawa/sms_confirmation.html.haml
@@ -1,0 +1,38 @@
+.single-container
+  %header.single-header
+    %h1.mercari-logo
+      = link_to image_tag("logo.svg", alt: "mercari"), "/yukawa", class: "mercari-logo__link"
+    %nav.progress-bar
+      %ol.clearfix
+        %li
+          会員情報
+          .progress-status.first{style: "background-color: red;"}
+        %li.active
+          電話番号認証
+          .progress-status.right-gray
+        %li 
+          お届け先住所入力
+          .progress-status.gray
+        %li 
+          支払い方法
+          .progress-status.gray
+        %li 
+          完了
+          .progress-status.last.gray
+  %main.single-main
+    %section.l-single-container
+      %h2.new-registration 電話番号の確認
+      %form.new-registration-form
+        .new-registration-form__content
+          .new-registration-form__content--form{style: "margin-top: 0;"}
+            %label{for: "phone_number"} 携帯電話の番号
+            %input.input-default{type: "tel", name: 'phone_number', placeholder: "携帯電話の番号を入力"}
+          %p.sms-info 本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用して認証を行います。
+          %button{type: "submit", class: "next-btn"}SMSを送信する
+          %p.sms-info ※電話番号は本人確認や不正利用防止のために利用します。他のユーザーに公開されることはありません。
+          .new-registration-form__content--form.text-right
+            %p
+              =link_to "電話番号の確認が必要な理由", "/yukawa/sms_confirmation", method: 'get'
+              =fa_icon "angle-right", class: "arrow-right"
+  %footer.single-footer
+    フッターは部分テンプレートです。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :yukawa do
     collection do
       get 'registration'
+      get 'sms_confirmation'
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
-WHAT
新規登録画面(メアド)がSMSに送信する部分まで終わりました。

-WHY
会員情報の入力の部分はレビューを依頼するのを忘れてしまいました。
yukawaというビューに新規会員登録のビューが入っています。

[私はロボットではありません],はあとで入れようと思ってるのでチェックボックスで代用しています。
