### PR TITLE
deploy時のエラーの修正

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ namespace :deploy do
       if test "[ ! -d #{shared_path}/config ]"
         execute "mkdir -p #{shared_path}/config"
       end
-      upload!('config/secrets.yml', "#{shared_path}/config/credentials.yml.enc")
+      upload!('config/credentials.yml.enc', "#{shared_path}/config/credentials.yml.enc")
     end
   end
   before :starting, 'deploy:upload'


### PR DESCRIPTION
＃　what 
secret.ymlをアップトードする設定になっていたのでcredentails.yml.encへ変更

# why
自動デプロイを可能にするため