### PR TITLE
画像の複数枚アップロード＆保存

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,7 @@ class ItemsController < ApplicationController
 
   def new 
     @item = Item.new
-    @item.images.build
+    10.times {@item.images.build}
   end
 
   
@@ -30,10 +30,6 @@ class ItemsController < ApplicationController
   private
   def item_params
     params.require(:item).permit(:name, :text, :state, :postage_type, :region, :shopping_date, :delivery_method, :price, images_attributes:[:image]).merge(user_id: current_user.id)
-  end
-
-  def image_params
-    parmas.require(:image).permit(:user_id, :image[])
   end
   
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,18 +17,8 @@
                 %span.mandatory 必須
               %p 最大10枚までアップロードできます
               .sell-form__image__container
-              = f.fields_for :images do |image|
-                .dropzone-container.clearfix
-                  #preview
-                  .dropzone-area
-                    = image.label :image, class: "dropzone-box", for: "upload-image" do
-                      .input_area
-                        = image.file_field :image, multiple: true, name: 'product_images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
-                  #preview
-                  .dropzone-area
-                    = image.label :image, class: "dropzone-box", for: "upload-image" do
-                      .input_area
-                        = image.file_field :image, multiple: true, name: 'product_images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
+              = f.fields_for :images do |i|
+                = i.file_field :image
                     
             .sell-form__information
               .sell-form__information__name

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,12 +17,18 @@
                 %span.mandatory 必須
               %p 最大10枚までアップロードできます
               .sell-form__image__container
-              = f.fields_for :images do |i|
-                = i.file_field :image
-                %pre
-                  :preserve
-                    ドラッグアンドドロップ
-                    またはクリックしてファイルをアップロード
+              = f.fields_for :images do |image|
+                .dropzone-container.clearfix
+                  #preview
+                  .dropzone-area
+                    = image.label :image, class: "dropzone-box", for: "upload-image" do
+                      .input_area
+                        = image.file_field :image, multiple: true, name: 'product_images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
+                  #preview
+                  .dropzone-area
+                    = image.label :image, class: "dropzone-box", for: "upload-image" do
+                      .input_area
+                        = image.file_field :image, multiple: true, name: 'product_images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
                     
             .sell-form__information
               .sell-form__information__name


### PR DESCRIPTION
What
imageとitemを親子関係のモデルとして関連付ける
strong parameterにattributesの記述（multiple: trueは使わない）

Why
画像の複数枚アップロードと保存のため