### PR TITLE
写真の１枚目のみ取得

### DIFF
--- a/app/views/shared/_item.html.haml
+++ b/app/views/shared/_item.html.haml
@@ -1,9 +1,13 @@
 - @other_items.each do |item|
   %section.item
-    = link_to  `/items/#{item.id}` do
+    = link_to  "/items/#{item.id}" do
       .item__photo
-        - item.images.each do |image|
-          = image_tag("#{image.image.url}")
+        -# = image_tag("#{item.images.image.url}")
+        - item.images.each_with_index do |image, index|
+          - if index == 0
+            = image_tag("#{image.image.url}")
+            - break
+            
       .item__body
         .item__body__name 
           = item.name


### PR DESCRIPTION
# what
詳細ページにおいて写真が複数枚ある商品は写真が多く表示されるので、最初の一枚のみを取得
# why
詳細ページの見た目を整える為