### PR TITLE
カテゴリー別に新着商品の表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,10 @@ class ItemsController < ApplicationController
   
   def index
     @items = Item.all.includes(:images).order('id DESC').limit(4)
-
+    @ladies = Item.where(category_id: 159..338).order("id DESC").limit(4)
+    @mens = Item.where(category_id: 339..469).order("id DESC").limit(4)
+    @kids = Item.where(category_id: 470..588).order("id DESC").limit(4)
+    @beauty = Item.where(category_id: 869..956).order("id DESC").limit(4)
     @q = Item.ransack(params[:q])
     @search_items = @q.result(distinct: true)
   end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -36,7 +36,7 @@
     %h3.top-main__contents__category
       = link_to "レディース 新着アイテム", root_path, class: "top-main__contents__category__link"
     .top-main__contents__items-wrap
-      - @items.each do |item|
+      - @ladies.each do |item|
         %section.top-main__contents__item-box
           -if item.status == 1
             .sold-out
@@ -62,7 +62,7 @@
     %h3.top-main__contents__category
       = link_to "メンズ 新着アイテム", root_path, class: "top-main__contents__category__link"
     .top-main__contents__items-wrap
-      - @items.each do |item|
+      - @mens.each do |item|
         %section.top-main__contents__item-box
           -if item.status == 1
             .sold-out
@@ -88,7 +88,7 @@
     %h3.top-main__contents__category
       = link_to "ベビー・キッズ 新着アイテム", root_path, class: "top-main__contents__category__link"
     .top-main__contents__items-wrap
-      - @items.each do |item|
+      - @kids.each do |item|
         %section.top-main__contents__item-box
           -if item.status == 1
             .sold-out
@@ -114,7 +114,7 @@
     %h3.top-main__contents__category
       = link_to "コスメ・香水・美容 新着アイテム", root_path, class: "top-main__contents__category__link"
     .top-main__contents__items-wrap
-      - @items.each do |item|
+      - @beauty.each do |item|
         %section.top-main__contents__item-box
           -if item.status == 1
             .sold-out


### PR DESCRIPTION
What
トップページに、レディース、メンズ、キッズ、美容系商品の新着をそれぞれカテゴリー別に分ける
上記4つの「すべての商品を見る」は最終スプリントで作成